### PR TITLE
Standard output names

### DIFF
--- a/muse.cwl
+++ b/muse.cwl
@@ -22,6 +22,8 @@ inputs:
     type: File
     inputBinding:
       prefix: -f
+    secondaryFiles:
+      - .fai
   known:
     type: File
     inputBinding:
@@ -37,7 +39,7 @@ inputs:
   run-id:
     type: string?
     inputBinding:
-      prefix: -O
+      prefix: --run-id
 
 
 outputs:

--- a/muse.cwl
+++ b/muse.cwl
@@ -1,10 +1,10 @@
 class: CommandLineTool
 label: MuSE
 cwlVersion: v1.0
-baseCommand: [/opt/bin/muse.py, -O, muse.vcf, -w, ./, --muse, MuSEv1.0rc]
+baseCommand: [/opt/bin/muse.py, -w, ./, --muse, MuSEv1.0rc]
 requirements:
   - class: "DockerRequirement"
-    dockerPull: "quay.io/pancancer/pcawg-muse:0.1.2"
+    dockerPull: "quay.io/pancancer/pcawg-muse:standard-output-names"
 inputs:
   tumor:
     type: File
@@ -30,11 +30,27 @@ inputs:
     type: {"type": "enum", "name": "Mode", "symbols": ["wgs", "wxs"]}
     inputBinding:
       prefix: --mode
+  coreNum:
+    type: int?
+    inputBinding:
+      prefix: -n
+  run-id:
+    type: string?
+    inputBinding:
+      prefix: -O
+
+
 outputs:
-  mutations:
+  somatic_snv_mnv_vcf_gz:
     type: File
     outputBinding:
-      glob: muse.vcf
+      glob: '*.somatic.snv_mnv.vcf.gz'
+    secondaryFiles:
+    - .md5
+    - .tbi
+    - .tbi.md5
+
+
 doc: |
     PCAWG MuSE variant calling workflow is developed by MD Anderson Cancer Center
     (http://bioinformatics.mdanderson.org/main/MuSE), it consists of software component calling structural

--- a/muse.py
+++ b/muse.py
@@ -81,9 +81,11 @@ def get_sm_from_bam(bam):
         rg_array = line.rstrip().split('\t')[1:]
         for element in rg_array:
             if not element.startswith('SM'): continue
-            sm.add(element.rstrip().split(':')[1])
+            value = element.replace("SM:","")
+            value = "".join([ c if re.match(r"[a-zA-Z\-_]", c) else "_" for c in value ])
+            sm.add(value)
 
-    if not len(sm) == 1: sys.exit("\nMultiple different SM entries %s:" % ":".join(list(sm)))
+    if not len(sm) == 1: sys.exit("\nDo not support multiple different SM entries %s:" % ", ".join(list(sm)))
     return sm.pop()
 
 def execute(cmd):

--- a/muse.py
+++ b/muse.py
@@ -2,6 +2,7 @@
 
 import sys
 import os
+import re
 import string
 import shutil
 import logging
@@ -114,6 +115,12 @@ def run_muse(args):
         sm = get_sm_from_bam(args.tumor_bam)
     else:
         sm = args.run_id
+
+    reg = re.compile('^[a-zA-Z0-9_-]+$')
+    if not reg.match(sm):
+        sys.exit('\nrun-id contains invalid character: %s\n' % sm)
+    else:
+        print "run-id:", sm
     dateString = datetime.now().strftime("%Y%m%d")
     output_vcf = '.'.join([sm, args.muse.replace(".", "-"), dateString, "somatic", "snv_mnv", "vcf"])
 

--- a/muse.py
+++ b/muse.py
@@ -65,7 +65,7 @@ def call_cmd_iter(muse, ref_seq, block_size, tumor_bam, normal_bam, contaminatio
             )
             yield cmd, "%s.%s.MuSE.txt" % (output_base, i)
 
-def get_sm_from_bam(bam):
+def get_run_id_from_sm_in_bam(bam):
     # retrieve the @RG from BAM header
     try:
         header = subprocess.check_output(['samtools', 'view', '-H', bam])
@@ -82,7 +82,7 @@ def get_sm_from_bam(bam):
         for element in rg_array:
             if not element.startswith('SM'): continue
             value = element.replace("SM:","")
-            value = "".join([ c if re.match(r"[a-zA-Z\-_]", c) else "_" for c in value ])
+            value = "".join([ c if re.match(r"[a-zA-Z0-9\-_]", c) else "_" for c in value ])
             sm.add(value)
 
     if not len(sm) == 1: sys.exit("\nDo not support multiple different SM entries, or no SM: %s:" % ", ".join(list(sm)))
@@ -114,7 +114,7 @@ def execute(cmd):
 def run_muse(args):
 
     if args.run_id is None:
-        sm = get_sm_from_bam(args.tumor_bam)
+        sm = get_run_id_from_sm_in_bam(args.tumor_bam)
     else:
         sm = args.run_id
 

--- a/muse.py
+++ b/muse.py
@@ -82,6 +82,7 @@ def get_sm_from_bam(bam):
         for element in rg_array:
             if not element.startswith('SM'): continue
             value = element.replace("SM:","")
+            value = "".join([ c if re.match(r"[a-zA-Z\-_]", c) else "_" for c in value ])
             sm.add(value)
 
     if not len(sm) == 1: sys.exit("\nDo not support multiple different SM entries, or no SM: %s:" % ", ".join(list(sm)))
@@ -117,8 +118,11 @@ def run_muse(args):
     else:
         sm = args.run_id
 
-    sm = "".join([c if re.match(r"[a-zA-Z0-9\-_]", c) else "_" for c in sm])
-    print "run-id:", sm
+    reg = re.compile('^[a-zA-Z0-9_-]+$')
+    if not reg.match(sm):
+        sys.exit('\nrun-id contains invalid character: %s\n' % sm)
+    else:
+        print "run-id:", sm
     dateString = datetime.now().strftime("%Y%m%d")
     output_vcf = '.'.join([sm, args.muse.replace(".", "-"), dateString, "somatic", "snv_mnv", "vcf"])
 

--- a/muse.py
+++ b/muse.py
@@ -100,12 +100,12 @@ def run_muse(args):
 
     workdir = os.path.abspath(tempfile.mkdtemp(dir=args.workdir, prefix="muse_work_"))
 
-    if args.O is None:
+    if args.run_id is None:
         sm = get_sm_from_bam(args.tumor_bam)
     else:
-        sm = args.O
+        sm = args.run_id
     dateString = datetime.now().strftime("%Y%m%d")
-    output_vcf = '.'.join([sm, args.muse+"-vcf", dateString, "somatic", "snv_mnv", "vcf"])
+    output_vcf = '.'.join([sm, args.muse.replace('.', '-'), dateString, "somatic", "snv_mnv", "vcf"])
 
 
     if not os.path.exists(args.f + ".fai"):
@@ -217,7 +217,7 @@ if __name__ == "__main__":
     #parser.add_argument("-l", help="list of regions (chr:pos-pos or BED), one region per line")
     parser.add_argument("-p", type=float, help="normal data contamination rate [0.050]", default=0.05)
     parser.add_argument("-b", type=long, help="Parallel Block Size", default=50000000)
-    parser.add_argument("-O", "--run_id", type=str, help="The output vcf file will be named following \
+    parser.add_argument("--run-id", dest="run_id", type=str, help="The output vcf file will be named following \
                         the convention: \
                         <run_id>.<workflowName>.<dateString>.somatic.snv_mnv.vcf.gz \
                         Otherwise the output vcf file will be named automatically \

--- a/muse.py
+++ b/muse.py
@@ -110,6 +110,13 @@ def execute(cmd):
 
 def run_muse(args):
 
+    if args.run_id is None:
+        sm = get_sm_from_bam(args.tumor_bam)
+    else:
+        sm = args.run_id
+    dateString = datetime.now().strftime("%Y%m%d")
+    output_vcf = '.'.join([sm, args.muse.replace(".", "-"), dateString, "somatic", "snv_mnv", "vcf"])
+
     mode_flag = ""
     if args.muse.endswith("MuSEv1.0rc"):
         args.p = None
@@ -122,14 +129,6 @@ def run_muse(args):
         args.muse = which(args.muse)
 
     workdir = os.path.abspath(tempfile.mkdtemp(dir=args.workdir, prefix="muse_work_"))
-
-    if args.run_id is None:
-        sm = get_sm_from_bam(args.tumor_bam)
-    else:
-        sm = args.run_id
-    dateString = datetime.now().strftime("%Y%m%d")
-    output_vcf = '.'.join([sm, args.muse.replace(".", "-"), dateString, "somatic", "snv_mnv", "vcf"])
-
 
     if not os.path.exists(args.f + ".fai"):
         new_ref = os.path.join(workdir, "ref_genome.fasta")

--- a/muse.py
+++ b/muse.py
@@ -80,7 +80,7 @@ def get_sm_from_bam(bam):
         rg_array = line.rstrip().split('\t')[1:]
         for element in rg_array:
             if not element.startswith('SM'): continue
-            sm.add(element.rstrip().split(':')[1:])
+            sm.add(element.rstrip().split(':')[1])
 
     if not len(sm) == 1: sys.exit("\nMultiple different SM entries %s:" % ":".join(list(sm)))
     return sm.pop

--- a/muse.py
+++ b/muse.py
@@ -85,7 +85,7 @@ def get_sm_from_bam(bam):
             value = "".join([ c if re.match(r"[a-zA-Z\-_]", c) else "_" for c in value ])
             sm.add(value)
 
-    if not len(sm) == 1: sys.exit("\nDo not support multiple different SM entries %s:" % ", ".join(list(sm)))
+    if not len(sm) == 1: sys.exit("\nDo not support multiple different SM entries, or no SM: %s:" % ", ".join(list(sm)))
     return sm.pop()
 
 def execute(cmd):

--- a/muse.py
+++ b/muse.py
@@ -82,7 +82,6 @@ def get_sm_from_bam(bam):
         for element in rg_array:
             if not element.startswith('SM'): continue
             value = element.replace("SM:","")
-            value = "".join([ c if re.match(r"[a-zA-Z\-_]", c) else "_" for c in value ])
             sm.add(value)
 
     if not len(sm) == 1: sys.exit("\nDo not support multiple different SM entries, or no SM: %s:" % ", ".join(list(sm)))
@@ -118,11 +117,8 @@ def run_muse(args):
     else:
         sm = args.run_id
 
-    reg = re.compile('^[a-zA-Z0-9_-]+$')
-    if not reg.match(sm):
-        sys.exit('\nrun-id contains invalid character: %s\n' % sm)
-    else:
-        print "run-id:", sm
+    sm = "".join([c if re.match(r"[a-zA-Z0-9\-_]", c) else "_" for c in sm])
+    print "run-id:", sm
     dateString = datetime.now().strftime("%Y%m%d")
     output_vcf = '.'.join([sm, args.muse.replace(".", "-"), dateString, "somatic", "snv_mnv", "vcf"])
 

--- a/muse.py
+++ b/muse.py
@@ -9,6 +9,7 @@ import logging
 import subprocess
 import tempfile
 from multiprocessing import Pool
+from multiprocessing import cpu_count
 from argparse import ArgumentParser
 
 def which(cmd):
@@ -177,7 +178,7 @@ if __name__ == "__main__":
 tabix indexed and based on the same reference
 genome used in 'MuSE call'""")
 
-    parser.add_argument("-n", "--cpus", type=int, default=8)
+    parser.add_argument("-n", "--cpus", type=int, default=cpu_count())
     parser.add_argument("-w", "--workdir", default="/tmp")
     parser.add_argument("--no-clean", action="store_true", default=False)
     parser.add_argument("--mode", choices=["wgs", "wxs"], default="wgs")


### PR DESCRIPTION
- expose the setting of coreNum optional to cwl level, if not provided, coreNum will be set to use all the cpu cores
- expose `run-id` to be optional at cwl level, if not provided `run-id` will be set as SM in RG of BAM header
- add code to bgzip, tabix and generate md5sum for the output vcf file
- standard the output files prefixed with the PCAWG convention: `<run-id>.<workflowName>.<dateString>....`